### PR TITLE
Correct empty Object check in empty host config unit test

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -195,7 +195,7 @@
 var mysql = require('mysql');
 
 module.exports = function (config) {
-  if (!config) {
+  if (!config || !Object.keys(config).length) {
     throw new Error('Need to provide MySQL connection information.');
   }
 


### PR DESCRIPTION
Unit test was failing because code was not correctly checking emptiness of `{}`.